### PR TITLE
Add source-coded WhatsApp greetings for attribution-safe contact

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -150,7 +150,35 @@ _Avoid_: top explanatory header inside the visual panel, crowded mobile controls
 
 **Lightly Qualified WhatsApp Message**:
 A prefilled WhatsApp message that asks for the minimum useful project context without blocking the chat.
-_Avoid_: generic greeting, required lead form
+_Avoid_: generic greeting, orçamento wording, required lead form
+
+**Simple WhatsApp Greeting**:
+A short prefilled WhatsApp opener that visitors are unlikely to rewrite before sending.
+_Avoid_: long qualification script, internal tracking label, orçamento request
+
+**Source-Coded WhatsApp Greeting**:
+A simple WhatsApp greeting whose wording or non-obvious marker lets BLK recover the originating source after the lead sends the message.
+_Avoid_: visible CTA label, strange-looking metadata, user-specific fingerprinting
+
+**Hidden WhatsApp Marker**:
+A non-visible marker embedded in a simple WhatsApp greeting so BLK can match the sent text back to a known source dictionary.
+_Avoid_: visible punctuation code, long tracking suffix, per-user fingerprinting
+
+**Message Attribution Boundary**:
+The rule that WhatsApp message text should not expose raw attribution fields such as UTM parameters or GCLID; those belong in analytics and storage.
+_Avoid_: utm_source text in WhatsApp, gclid text in WhatsApp, internal campaign metadata in the lead's message
+
+**WhatsApp Marker Placement**:
+The position where a hidden WhatsApp marker is embedded in the greeting, such as before the visible text or after the first greeting word, to increase the source dictionary's option space.
+_Avoid_: placing markers where they visibly disrupt the greeting, random placement, user-specific placement
+
+**Deterministic WhatsApp Greeting**:
+A source-coded WhatsApp greeting that stays stable for the same campaign and site touchpoint instead of changing by time of day or session.
+_Avoid_: time-of-day variants, random greetings, per-user message fingerprints
+
+**Proposal-Led Contact**:
+The commercial framing that positions the first WhatsApp conversation around understanding the project and preparing a value-based proposal.
+_Avoid_: orçamento request, price-only contact, quote-first language
 
 **Final WhatsApp Composer**:
 The final homepage CTA pattern where visitors provide a location and select their objective before opening a prefilled WhatsApp conversation.

--- a/src/components/HomeFinalWhatsAppComposer.astro
+++ b/src/components/HomeFinalWhatsAppComposer.astro
@@ -1,6 +1,7 @@
 ---
 import BrandIcon from "./BrandIcon.astro";
 import { getWhatsAppNumber } from "../lib/contact";
+import { buildWhatsAppUrl } from "../lib/whatsapp";
 
 type Props = {
   content: {
@@ -18,6 +19,7 @@ type Props = {
 
 const { content, primaryCtaLabel } = Astro.props as Props;
 const number = getWhatsAppNumber();
+const href = buildWhatsAppUrl(number, { ctaLocation: "final-cta" });
 ---
 
 <section
@@ -58,7 +60,7 @@ const number = getWhatsAppNumber();
       </label>
       <a
         class="btn-primary inline-flex items-center justify-center gap-2 rounded-lg px-5 py-3 text-sm font-semibold sm:self-end"
-        href={`https://wa.me/${number}?text=${encodeURIComponent("Olá! Quero orçamento. CTA: final-cta.")}`}
+        href={href}
         target="_blank"
         rel="noopener noreferrer"
         data-final-whatsapp-submit
@@ -69,89 +71,3 @@ const number = getWhatsAppNumber();
     </form>
   </div>
 </section>
-
-<script is:inline>
-  (function () {
-    const storageKey = "blk_attribution_v1";
-    const keys = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "gclid"];
-
-    function readStored() {
-      try {
-        return JSON.parse(sessionStorage.getItem(storageKey) || "{}");
-      } catch {
-        return {};
-      }
-    }
-
-    function readCurrentParams() {
-      const params = new URLSearchParams(window.location.search);
-      const out = {};
-      keys.forEach((key) => {
-        const value = params.get(key);
-        if (value) out[key] = value;
-      });
-      return out;
-    }
-
-    function append(parts, label, value) {
-      if (value) parts.push(`${label}: ${value}.`);
-    }
-
-    function buildMessage(payload, attribution) {
-      const parts = ["Olá! Quero orçamento."];
-      append(parts, "Localização", payload.location);
-      append(parts, "Objetivo", payload.objective);
-      append(parts, "CTA", payload.ctaLocation);
-      const pairs = Object.entries(attribution).map(([key, value]) => `${key}=${value}`);
-      if (pairs.length) parts.push(pairs.join(" "));
-      return parts.join(" ");
-    }
-
-    document.querySelectorAll("[data-final-whatsapp-form]").forEach((form) => {
-      if (!(form instanceof HTMLFormElement)) return;
-      if (form.dataset.bound === "1") return;
-      form.dataset.bound = "1";
-
-      const submit = form.querySelector("[data-final-whatsapp-submit]");
-      if (!(submit instanceof HTMLAnchorElement)) return;
-
-      const number = (form.dataset.whatsappNumber || "").replace(/\D/g, "");
-      const ctaLocation = form.dataset.ctaLocation || "";
-      const attribution = { ...readCurrentParams(), ...readStored() };
-      if (Object.keys(attribution).length > 0) {
-        sessionStorage.setItem(storageKey, JSON.stringify(attribution));
-      }
-
-      function payload() {
-        const data = new FormData(form);
-        return {
-          location: String(data.get("location") || "").trim(),
-          objective: String(data.get("objective") || "").trim(),
-          ctaLocation
-        };
-      }
-
-      function syncHref() {
-        submit.href = `https://wa.me/${number}?text=${encodeURIComponent(buildMessage(payload(), attribution))}`;
-      }
-
-      syncHref();
-      form.addEventListener("input", syncHref);
-      form.addEventListener("change", syncHref);
-      form.addEventListener("submit", (event) => event.preventDefault());
-
-      submit.addEventListener("click", () => {
-        const currentPayload = payload();
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({
-          event: "whatsapp_click",
-          page_path: window.location.pathname,
-          cta_location: ctaLocation || undefined,
-          location: currentPayload.location || undefined,
-          objective: currentPayload.objective || undefined,
-          ...attribution
-        });
-      });
-    });
-  })();
-</script>

--- a/src/components/WhatsAppCTA.astro
+++ b/src/components/WhatsAppCTA.astro
@@ -47,6 +47,7 @@ const href = buildWhatsAppUrl(number, {
 
 <a
   data-testid="whatsapp-cta"
+  data-whatsapp-link
   data-whatsapp-number={number}
   data-service={service ?? ""}
   data-city={city ?? ""}
@@ -69,87 +70,3 @@ const href = buildWhatsAppUrl(number, {
     <span>{label}</span>
   </span>
 </a>
-
-<script is:inline>
-  (function () {
-    const storageKey = "blk_attribution_v1";
-    const keys = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "gclid"];
-
-    function readStored() {
-      try {
-        return JSON.parse(sessionStorage.getItem(storageKey) || "{}");
-      } catch {
-        return {};
-      }
-    }
-
-    function readCurrentParams() {
-      const params = new URLSearchParams(window.location.search);
-      const out = {};
-      keys.forEach((key) => {
-        const value = params.get(key);
-        if (value) out[key] = value;
-      });
-      return out;
-    }
-
-    function append(parts, label, value) {
-      if (value) parts.push(`${label}: ${value}.`);
-    }
-
-    function buildMessage(payload, attribution) {
-      const parts = ["Olá! Quero orçamento."];
-      append(parts, "Serviço", payload.service);
-      append(parts, "Cidade", payload.city);
-      append(parts, "Localização", payload.location);
-      append(parts, "Área/perímetro aproximado", payload.approximateAreaOrPerimeter);
-      append(parts, "Objetivo", payload.objective);
-      append(parts, "Prazo desejado", payload.deadline);
-      append(parts, "Entrega desejada", payload.desiredDeliverable);
-      append(parts, "Cluster selecionado", payload.selectedCluster);
-      append(parts, "CTA", payload.ctaLocation);
-      const pairs = Object.entries(attribution).map(([k, v]) => `${k}=${v}`);
-      if (pairs.length) parts.push(pairs.join(" "));
-      return parts.join(" ");
-    }
-
-    document.querySelectorAll("[data-testid='whatsapp-cta']").forEach((node) => {
-      if (!(node instanceof HTMLAnchorElement)) return;
-      if (node.dataset.bound === "1") return;
-      node.dataset.bound = "1";
-
-      const number = (node.dataset.whatsappNumber || "").replace(/\D/g, "");
-      const payload = {
-        service: node.dataset.service || "",
-        city: node.dataset.city || "",
-        location: node.dataset.location || "",
-        approximateAreaOrPerimeter: node.dataset.approximateAreaOrPerimeter || "",
-        objective: node.dataset.objective || "",
-        deadline: node.dataset.deadline || "",
-        desiredDeliverable: node.dataset.desiredDeliverable || "",
-        selectedCluster: node.dataset.selectedCluster || "",
-        ctaLocation: node.dataset.ctaLocation || ""
-      };
-      const attribution = { ...readCurrentParams(), ...readStored() };
-      if (Object.keys(attribution).length > 0) {
-        sessionStorage.setItem(storageKey, JSON.stringify(attribution));
-      }
-
-      const message = buildMessage(payload, attribution);
-      node.href = `https://wa.me/${number}?text=${encodeURIComponent(message)}`;
-
-      node.addEventListener("click", () => {
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({
-          event: "whatsapp_click",
-          service: payload.service || undefined,
-          city: payload.city || undefined,
-          selected_cluster: payload.selectedCluster || undefined,
-          cta_location: payload.ctaLocation || undefined,
-          page_path: window.location.pathname,
-          ...attribution
-        });
-      });
-    });
-  })();
-</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,7 +8,7 @@ import BrandIcon from "../components/BrandIcon.astro";
 import ConsentBanner from "../components/ConsentBanner.astro";
 import GtmHead from "../components/GtmHead.astro";
 import SeoHead from "../components/SeoHead.astro";
-import { buildDefaultWhatsAppUrl } from "../lib/contact";
+import { buildDefaultWhatsAppUrl, getWhatsAppNumber } from "../lib/contact";
 import { isBrandIconName } from "../lib/brand-icons";
 import { getSiteConfig } from "../lib/site-config";
 
@@ -28,12 +28,9 @@ const {
 
 const siteConfig = await getSiteConfig();
 const pageDescription = description ?? siteConfig.meta.default_description;
-const navWhatsAppHref = buildDefaultWhatsAppUrl({
-  intro: siteConfig.contact.whatsapp.nav_intro
-});
-const footerWhatsAppHref = buildDefaultWhatsAppUrl({
-  intro: siteConfig.contact.whatsapp.footer_intro
-});
+const whatsAppNumber = getWhatsAppNumber();
+const navWhatsAppHref = buildDefaultWhatsAppUrl({ ctaLocation: "nav" });
+const footerWhatsAppHref = buildDefaultWhatsAppUrl({ ctaLocation: "footer" });
 const navLinks = siteConfig.navigation.primary_links;
 const currentYear = new Date().getFullYear();
 const legalEntity = "BLK Gestão Empresarial Ltda. (CNPJ: 37.814.104-0001/40)";
@@ -91,6 +88,9 @@ const faviconSrc = typeof faviconPng === "string" ? faviconPng : faviconPng.src;
             target="_blank"
             rel="noopener noreferrer"
             data-testid="nav-whatsapp-cta"
+            data-whatsapp-link
+            data-whatsapp-number={whatsAppNumber}
+            data-cta-location="nav"
             aria-label="WhatsApp"
           >
             <span aria-hidden="true" class="inline-flex h-4 w-4">
@@ -160,6 +160,7 @@ const faviconSrc = typeof faviconPng === "string" ? faviconPng : faviconPng.src;
                 <ul class="space-y-3 text-sm font-medium text-gray-600">
                   {column.links.map((link) => {
                     const external = isExternalHref(link.href);
+                    const whatsappContact = link.href.startsWith("https://wa.me/");
                     return (
                       <li>
                         <a
@@ -167,6 +168,9 @@ const faviconSrc = typeof faviconPng === "string" ? faviconPng : faviconPng.src;
                           href={link.href}
                           target={external ? "_blank" : undefined}
                           rel={external ? "noopener noreferrer" : undefined}
+                          data-whatsapp-link={whatsappContact ? "true" : undefined}
+                          data-whatsapp-number={whatsappContact ? whatsAppNumber : undefined}
+                          data-cta-location={whatsappContact ? "footer" : undefined}
                         >
                           {link.label}
                         </a>
@@ -211,6 +215,134 @@ const faviconSrc = typeof faviconPng === "string" ? faviconPng : faviconPng.src;
 
       initAccordions();
       initCollapses();
+    </script>
+    <script>
+      import { mergeFirstTouchAttribution } from "../lib/attribution";
+      import { buildWhatsAppUrl, selectSourceCodedWhatsAppGreeting } from "../lib/whatsapp";
+
+      (function () {
+        const storageKey = "blk_attribution_v1";
+        const keys = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "gclid"];
+
+        function readStored() {
+          try {
+            return JSON.parse(sessionStorage.getItem(storageKey) || "{}");
+          } catch {
+            return {};
+          }
+        }
+
+        function readCurrentParams() {
+          const params = new URLSearchParams(window.location.search);
+          const out = {};
+          keys.forEach((key) => {
+            const value = params.get(key);
+            if (value) out[key] = value;
+          });
+          return out;
+        }
+
+        function readAttribution() {
+          const attribution = mergeFirstTouchAttribution(readStored(), readCurrentParams());
+          if (Object.keys(attribution).length > 0) {
+            sessionStorage.setItem(storageKey, JSON.stringify(attribution));
+          }
+          return attribution;
+        }
+
+        function anchorPayload(node) {
+          return {
+            service: node.dataset.service || "",
+            city: node.dataset.city || "",
+            location: node.dataset.location || "",
+            approximateAreaOrPerimeter: node.dataset.approximateAreaOrPerimeter || "",
+            objective: node.dataset.objective || "",
+            deadline: node.dataset.deadline || "",
+            desiredDeliverable: node.dataset.desiredDeliverable || "",
+            selectedCluster: node.dataset.selectedCluster || "",
+            ctaLocation: node.dataset.ctaLocation || ""
+          };
+        }
+
+        function syncAnchor(node) {
+          const payload = anchorPayload(node);
+          const attribution = readAttribution();
+          const payloadWithAttribution = { ...payload, attribution };
+          const greeting = selectSourceCodedWhatsAppGreeting(payloadWithAttribution);
+          node.href = buildWhatsAppUrl(node.dataset.whatsappNumber || "", payloadWithAttribution);
+          node.dataset.whatsappGreetingId = greeting.id;
+          return { payload, attribution, greeting };
+        }
+
+        document.querySelectorAll("[data-whatsapp-link]").forEach((node) => {
+          if (!(node instanceof HTMLAnchorElement)) return;
+          if (node.dataset.bound === "1") return;
+          node.dataset.bound = "1";
+          syncAnchor(node);
+
+          node.addEventListener("click", () => {
+            const { payload, attribution, greeting } = syncAnchor(node);
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push({
+              event: "whatsapp_click",
+              service: payload.service || undefined,
+              city: payload.city || undefined,
+              selected_cluster: payload.selectedCluster || undefined,
+              cta_location: payload.ctaLocation || undefined,
+              whatsapp_greeting_id: greeting.id,
+              page_path: window.location.pathname,
+              ...attribution
+            });
+          });
+        });
+
+        document.querySelectorAll("[data-final-whatsapp-form]").forEach((form) => {
+          if (!(form instanceof HTMLFormElement)) return;
+          if (form.dataset.bound === "1") return;
+          form.dataset.bound = "1";
+
+          const submit = form.querySelector("[data-final-whatsapp-submit]");
+          if (!(submit instanceof HTMLAnchorElement)) return;
+
+          function payload() {
+            const data = new FormData(form);
+            return {
+              location: String(data.get("location") || "").trim(),
+              objective: String(data.get("objective") || "").trim(),
+              ctaLocation: form.dataset.ctaLocation || ""
+            };
+          }
+
+          function syncHref() {
+            const attribution = readAttribution();
+            const payloadWithAttribution = { ...payload(), attribution };
+            const greeting = selectSourceCodedWhatsAppGreeting(payloadWithAttribution);
+            submit.href = buildWhatsAppUrl(form.dataset.whatsappNumber || "", payloadWithAttribution);
+            submit.dataset.whatsappGreetingId = greeting.id;
+            return { attribution, greeting };
+          }
+
+          syncHref();
+          form.addEventListener("input", syncHref);
+          form.addEventListener("change", syncHref);
+          form.addEventListener("submit", (event) => event.preventDefault());
+
+          submit.addEventListener("click", () => {
+            const currentPayload = payload();
+            const { attribution, greeting } = syncHref();
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push({
+              event: "whatsapp_click",
+              page_path: window.location.pathname,
+              cta_location: currentPayload.ctaLocation || undefined,
+              whatsapp_greeting_id: greeting.id,
+              location: currentPayload.location || undefined,
+              objective: currentPayload.objective || undefined,
+              ...attribution
+            });
+          });
+        });
+      })();
     </script>
   </body>
 </html>

--- a/src/lib/whatsapp.ts
+++ b/src/lib/whatsapp.ts
@@ -1,5 +1,18 @@
 import type { Attribution } from "./attribution";
 
+export type WhatsAppMarkerPlacement = "prefix" | "after-greeting-word";
+
+export type SourceCodedWhatsAppGreeting = {
+  id: string;
+  touchpoint: string;
+  visibleText: string;
+  marker: string;
+  placement: WhatsAppMarkerPlacement;
+  source?: string;
+  medium?: string;
+  campaign?: string;
+};
+
 export type WhatsAppPayload = {
   service?: string | null;
   city?: string | null;
@@ -14,57 +27,146 @@ export type WhatsAppPayload = {
   intro?: string;
 };
 
-function buildAttributionText(attribution: Attribution = {}): string {
-  const entries = Object.entries(attribution).filter(([, value]) => Boolean(value));
-  if (entries.length === 0) return "";
-  return entries.map(([key, value]) => `${key}=${value}`).join(" ");
+export const sourceCodedWhatsAppGreetings: SourceCodedWhatsAppGreeting[] = [
+  {
+    id: "google-cpc-home.home-hero.v1",
+    source: "google",
+    medium: "cpc",
+    campaign: "home",
+    touchpoint: "home-hero",
+    visibleText: "Oi, quero falar com a BLK.",
+    marker: "\u200E\u00A0\u200B",
+    placement: "prefix"
+  },
+  {
+    id: "default.nav.v1",
+    touchpoint: "nav",
+    visibleText: "Oi, quero falar com a BLK.",
+    marker: "\u200E\u00A0",
+    placement: "prefix"
+  },
+  {
+    id: "default.home-hero.v1",
+    touchpoint: "home-hero",
+    visibleText: "Oi, quero falar com a BLK.",
+    marker: "\u200B",
+    placement: "prefix"
+  },
+  {
+    id: "default.triage-section.v1",
+    touchpoint: "triage-section",
+    visibleText: "Oi, gostaria de falar com a BLK.",
+    marker: "\u200C",
+    placement: "after-greeting-word"
+  },
+  {
+    id: "default.final-cta.v1",
+    touchpoint: "final-cta",
+    visibleText: "Oi, quero falar com a BLK.",
+    marker: "\u200D",
+    placement: "prefix"
+  },
+  {
+    id: "default.footer.v1",
+    touchpoint: "footer",
+    visibleText: "Olá, quero falar com a BLK.",
+    marker: "\u2800",
+    placement: "prefix"
+  },
+  {
+    id: "default.site.v1",
+    touchpoint: "site",
+    visibleText: "Oi, quero falar com a BLK.",
+    marker: "\u00A0",
+    placement: "prefix"
+  }
+];
+
+function normalizeTouchpoint(ctaLocation?: string | null): string {
+  return ctaLocation && ctaLocation.trim().length > 0 ? ctaLocation.trim() : "site";
+}
+
+function matchesAttribution(
+  entry: SourceCodedWhatsAppGreeting,
+  attribution: Attribution,
+  requirements: Pick<SourceCodedWhatsAppGreeting, "source" | "medium" | "campaign">
+): boolean {
+  return (
+    entry.source === requirements.source &&
+    entry.medium === requirements.medium &&
+    entry.campaign === requirements.campaign &&
+    (!entry.source || entry.source === attribution.utm_source) &&
+    (!entry.medium || entry.medium === attribution.utm_medium) &&
+    (!entry.campaign || entry.campaign === attribution.utm_campaign)
+  );
+}
+
+export function selectSourceCodedWhatsAppGreeting(
+  payload: Pick<WhatsAppPayload, "ctaLocation" | "attribution"> = {}
+): SourceCodedWhatsAppGreeting {
+  const touchpoint = normalizeTouchpoint(payload.ctaLocation);
+  const attribution = payload.attribution ?? {};
+  const source = attribution.utm_source;
+  const medium = attribution.utm_medium;
+  const campaign = attribution.utm_campaign;
+  const attributionFallbacks = [
+    { source, medium, campaign },
+    { source, medium, campaign: undefined },
+    { source, medium: undefined, campaign: undefined },
+    { source: undefined, medium: undefined, campaign: undefined }
+  ];
+
+  for (const requirements of attributionFallbacks) {
+    const match = sourceCodedWhatsAppGreetings.find(
+      (entry) => entry.touchpoint === touchpoint && matchesAttribution(entry, attribution, requirements)
+    );
+    if (match) return match;
+  }
+
+  return (
+    sourceCodedWhatsAppGreetings.find((entry) => entry.id === "default.site.v1") ??
+    sourceCodedWhatsAppGreetings[0]
+  );
+}
+
+export function applySourceCodedWhatsAppMarker(entry: SourceCodedWhatsAppGreeting): string {
+  if (entry.placement === "prefix") {
+    return `${entry.marker}${entry.visibleText}`;
+  }
+
+  const greetingWord = entry.visibleText.match(/^[\p{L}\p{N}]+/u)?.[0];
+  if (!greetingWord) {
+    return `${entry.marker}${entry.visibleText}`;
+  }
+
+  return `${greetingWord}${entry.marker}${entry.visibleText.slice(greetingWord.length)}`;
+}
+
+function append(parts: string[], label: string, value?: string | null): void {
+  if (value) parts.push(`${label}: ${value}.`);
 }
 
 export function buildWhatsAppMessage(payload: WhatsAppPayload = {}): string {
-  const parts: string[] = [payload.intro ?? "Olá! Quero orçamento."];
+  const greeting = selectSourceCodedWhatsAppGreeting(payload);
+  const parts: string[] = [applySourceCodedWhatsAppMarker(greeting)];
 
-  if (payload.service) {
-    parts.push(`Serviço: ${payload.service}.`);
+  if (normalizeTouchpoint(payload.ctaLocation) === "final-cta") {
+    append(parts, "Localização", payload.location);
+    append(parts, "Objetivo", payload.objective);
   }
 
-  if (payload.city) {
-    parts.push(`Cidade: ${payload.city}.`);
-  }
+  return parts.join("\n\n");
+}
 
-  if (payload.location) {
-    parts.push(`Localização: ${payload.location}.`);
-  }
-
-  if (payload.approximateAreaOrPerimeter) {
-    parts.push(`Área/perímetro aproximado: ${payload.approximateAreaOrPerimeter}.`);
-  }
-
-  if (payload.objective) {
-    parts.push(`Objetivo: ${payload.objective}.`);
-  }
-
-  if (payload.deadline) {
-    parts.push(`Prazo desejado: ${payload.deadline}.`);
-  }
-
-  if (payload.desiredDeliverable) {
-    parts.push(`Entrega desejada: ${payload.desiredDeliverable}.`);
-  }
-
-  if (payload.selectedCluster) {
-    parts.push(`Cluster selecionado: ${payload.selectedCluster}.`);
-  }
-
-  if (payload.ctaLocation) {
-    parts.push(`CTA: ${payload.ctaLocation}.`);
-  }
-
-  const attributionText = buildAttributionText(payload.attribution);
-  if (attributionText) {
-    parts.push(attributionText);
-  }
-
-  return parts.join(" ");
+export function decodeSourceCodedWhatsAppMessage(
+  message: string
+): SourceCodedWhatsAppGreeting | null {
+  return (
+    sourceCodedWhatsAppGreetings
+      .map((entry) => ({ entry, markedText: applySourceCodedWhatsAppMarker(entry) }))
+      .sort((a, b) => b.markedText.length - a.markedText.length)
+      .find(({ markedText }) => message.startsWith(markedText))?.entry ?? null
+  );
 }
 
 export function buildWhatsAppUrl(number: string, payload: WhatsAppPayload = {}): string {

--- a/tests/e2e/conversion-flow.spec.ts
+++ b/tests/e2e/conversion-flow.spec.ts
@@ -1,26 +1,78 @@
 import { test, expect } from "@playwright/test";
 
-test("utm survives internal navigation for whatsapp", async ({ page }) => {
+function whatsappTextFromHref(href: string | null): string {
+  return new URL(href || "").searchParams.get("text") || "";
+}
+
+function visibleWhatsAppText(text: string): string {
+  return text.replace(/[\u200E\u00A0\u200B\u200C\u200D\u2800]/g, "");
+}
+
+test("utm survives internal navigation in whatsapp click analytics", async ({ page }) => {
   await page.goto("/blog?utm_source=google&utm_medium=cpc&utm_campaign=teste&gclid=abc123");
 
   await page.goto("/");
 
-  const href = await page.locator('[data-testid="whatsapp-cta"]').first().getAttribute("href");
-  expect(decodeURIComponent(href || "")).toContain("gclid=abc123");
+  const cta = page.locator('[data-testid="whatsapp-cta"]').first();
+  const href = await cta.getAttribute("href");
+  expect(whatsappTextFromHref(href)).not.toContain("gclid");
+
+  await cta.dispatchEvent("click");
+
+  const payload = await page.evaluate(() => {
+    const events = Array.isArray(window.dataLayer) ? window.dataLayer : [];
+    return events.find((event) => event.event === "whatsapp_click");
+  });
+
+  expect(payload).toMatchObject({
+    gclid: "abc123",
+    utm_source: "google"
+  });
 });
 
-test("homepage whatsapp CTA includes CTA location and attribution in URL and click payload", async ({
+test("first-touch attribution wins over later conflicting campaign params", async ({ page }) => {
+  await page.goto("/?utm_source=google&utm_medium=cpc&utm_campaign=home&gclid=first-click");
+  await page.goto(
+    "/?utm_source=linkedin&utm_medium=social&utm_campaign=retargeting&utm_content=later&gclid=second-click"
+  );
+
+  const cta = page.locator('[data-testid="whatsapp-cta"]').first();
+  const text = whatsappTextFromHref(await cta.getAttribute("href"));
+  expect(text).not.toContain("utm_source");
+  expect(text).not.toContain("gclid");
+
+  await cta.dispatchEvent("click");
+
+  const payload = await page.evaluate(() => {
+    const events = Array.isArray(window.dataLayer) ? window.dataLayer : [];
+    return events.find((event) => event.event === "whatsapp_click");
+  });
+
+  expect(payload).toMatchObject({
+    cta_location: "home-hero",
+    whatsapp_greeting_id: "google-cpc-home.home-hero.v1",
+    utm_source: "google",
+    utm_medium: "cpc",
+    utm_campaign: "home",
+    utm_content: "later",
+    gclid: "first-click"
+  });
+});
+
+test("homepage whatsapp CTA keeps message simple while click payload keeps attribution", async ({
   page
 }) => {
-  await page.goto("/?utm_source=google&utm_campaign=home&gclid=abc123");
+  await page.goto("/?utm_source=google&utm_medium=cpc&utm_campaign=home&gclid=abc123");
 
   const cta = page.locator('[data-testid="whatsapp-cta"]').first();
   await expect(cta).toBeVisible();
 
-  const href = decodeURIComponent((await cta.getAttribute("href")) || "");
-  expect(href).toContain("CTA: home-hero.");
-  expect(href).toContain("utm_source=google");
-  expect(href).toContain("gclid=abc123");
+  const text = whatsappTextFromHref(await cta.getAttribute("href"));
+  expect(visibleWhatsAppText(text)).toContain("Oi, quero falar com a BLK.");
+  expect(text).not.toContain("CTA:");
+  expect(text).not.toContain("utm_source");
+  expect(text).not.toContain("gclid");
+  expect(text).not.toContain("orçamento");
 
   await cta.dispatchEvent("click");
 
@@ -48,10 +100,11 @@ test("homepage triage section whatsapp CTA includes section location and attribu
   await expect(cta).toBeVisible();
   await expect(triageSection.locator("article").getByRole("link", { name: "Falar com especialista" })).toHaveCount(0);
 
-  const href = decodeURIComponent((await cta.getAttribute("href")) || "");
-  expect(href).not.toContain("Cluster selecionado:");
-  expect(href).toContain("CTA: triage-section.");
-  expect(href).toContain("gclid=abc123");
+  const text = whatsappTextFromHref(await cta.getAttribute("href"));
+  expect(visibleWhatsAppText(text)).toContain("Oi, gostaria de falar com a BLK.");
+  expect(text).not.toContain("Cluster selecionado:");
+  expect(text).not.toContain("CTA:");
+  expect(text).not.toContain("gclid");
 
   await cta.dispatchEvent("click");
 
@@ -91,9 +144,11 @@ test("homepage final CTA composer uses shared whatsapp payload behavior", async 
   await expect(finalCta).toBeVisible();
 
   await expect(objective).toHaveValue("");
-  const initialHref = decodeURIComponent((await finalCta.getAttribute("href")) || "");
-  expect(initialHref).toContain("CTA: final-cta.");
-  expect(initialHref).not.toContain("Objetivo:");
+  const initialText = whatsappTextFromHref(await finalCta.getAttribute("href"));
+  expect(visibleWhatsAppText(initialText)).toContain("Oi, quero falar com a BLK.");
+  expect(initialText).not.toContain("CTA:");
+  expect(initialText).not.toContain("Objetivo:");
+  expect(initialText).not.toContain("gclid");
 
   const sectionBox = await finalSection.boundingBox();
   const headingBox = await finalHeading.boundingBox();
@@ -118,11 +173,11 @@ test("homepage final CTA composer uses shared whatsapp payload behavior", async 
   await location.fill("São José dos Campos - https://maps.app.goo.gl/exemplo");
   await objective.selectOption("Regularização Rural");
 
-  const href = decodeURIComponent((await finalCta.getAttribute("href")) || "");
-  expect(href).toContain("CTA: final-cta.");
-  expect(href).toContain("gclid=abc123");
-  expect(href).toContain("Localização: São José dos Campos - https://maps.app.goo.gl/exemplo.");
-  expect(href).toContain("Objetivo: Regularização Rural.");
+  const text = whatsappTextFromHref(await finalCta.getAttribute("href"));
+  expect(text).not.toContain("CTA:");
+  expect(text).not.toContain("gclid");
+  expect(text).toContain("Localização: São José dos Campos - https://maps.app.goo.gl/exemplo.");
+  expect(text).toContain("Objetivo: Regularização Rural.");
 
   await finalCta.dispatchEvent("click");
 

--- a/tests/e2e/footer-social.spec.ts
+++ b/tests/e2e/footer-social.spec.ts
@@ -7,7 +7,12 @@ test("footer shows BLK contact and trust details without template social links",
   const footerLogo = footer.getByRole("link", { name: "BLK Aero" }).locator("img");
   await expect(footerLogo).toHaveAttribute("src", /logo_inline_grey_fulltext_aero_nobackground/);
   await expect(footer.getByRole("link", { name: "contato@blk.aero" })).toHaveAttribute("href", "mailto:contato@blk.aero");
-  await expect(footer.getByRole("link", { name: "(12) 98806-2737" })).toHaveAttribute("href", /wa\.me\/5512988062737/);
+  const phoneLink = footer.getByRole("link", { name: "(12) 98806-2737" });
+  await expect(phoneLink).toHaveAttribute("href", /wa\.me\/5512988062737/);
+  const phoneText = new URL((await phoneLink.getAttribute("href")) || "").searchParams.get("text") || "";
+  expect(phoneText).toContain("Olá, quero falar com a BLK.");
+  expect(phoneText).not.toContain("CTA:");
+  expect(phoneText).not.toContain("orçamento");
   await expect(footer).toContainText("Categoria A em Aerolevantamento pelo Ministério da Defesa");
   const footerLinks = footer
     .getByRole("heading", { name: "Navegação" })

--- a/tests/e2e/navigation-whatsapp.spec.ts
+++ b/tests/e2e/navigation-whatsapp.spec.ts
@@ -14,6 +14,10 @@ test("header contact links to whatsapp instead of tel", async ({ page }) => {
   const href = await contact.getAttribute("href");
   expect(href).toContain("wa.me/");
   expect(href).not.toContain("tel:");
+  const text = new URL(href || "").searchParams.get("text") || "";
+  expect(text).toContain("Oi, quero falar com a BLK.");
+  expect(text).not.toContain("CTA:");
+  expect(text).not.toContain("orçamento");
 });
 
 test("header uses vanilla Flowbite navbar spacing and logo size", async ({ page }) => {

--- a/tests/lib/whatsapp.test.ts
+++ b/tests/lib/whatsapp.test.ts
@@ -1,41 +1,104 @@
 import { describe, it, expect } from "vitest";
-import { buildWhatsAppUrl } from "../../src/lib/whatsapp";
+import {
+  applySourceCodedWhatsAppMarker,
+  buildWhatsAppMessage,
+  buildWhatsAppUrl,
+  decodeSourceCodedWhatsAppMessage,
+  selectSourceCodedWhatsAppGreeting,
+  sourceCodedWhatsAppGreetings
+} from "../../src/lib/whatsapp";
+
+function textFromUrl(url: string): string {
+  return new URL(url).searchParams.get("text") || "";
+}
+
+function codePoints(value: string): string[] {
+  return Array.from(value).map((char) => char.codePointAt(0)?.toString(16) || "");
+}
 
 describe("whatsapp url", () => {
-  it("includes service city and attribution in text", () => {
+  it("builds a source-coded greeting without exposing attribution text", () => {
     const url = buildWhatsAppUrl("5511999999999", {
-      service: "georreferenciamento-de-imovel-rural",
-      city: "jacarei-sp",
-      attribution: { utm_source: "google", gclid: "abc123" }
+      ctaLocation: "home-hero",
+      attribution: { utm_source: "google", utm_medium: "cpc", utm_campaign: "home", gclid: "abc123" }
     });
+    const text = textFromUrl(url);
+    const decoded = decodeSourceCodedWhatsAppMessage(text);
 
     expect(url).toContain("wa.me/5511999999999");
-    expect(decodeURIComponent(url)).toContain("georreferenciamento-de-imovel-rural");
-    expect(decodeURIComponent(url)).toContain("jacarei-sp");
-    expect(decodeURIComponent(url)).toContain("gclid=abc123");
+    expect(decoded?.id).toBe("google-cpc-home.home-hero.v1");
+    expect(text).toContain("Oi, quero falar com a BLK.");
+    expect(text).not.toContain("orçamento");
+    expect(text).not.toContain("CTA:");
+    expect(text).not.toContain("utm_source");
+    expect(text).not.toContain("gclid");
   });
 
-  it("includes homepage CTA qualification and segmentation fields in text", () => {
+  it("keeps exact hidden marker code points in explicit dictionary entries", () => {
+    const nav = sourceCodedWhatsAppGreetings.find((entry) => entry.id === "default.nav.v1");
+    const triage = sourceCodedWhatsAppGreetings.find((entry) => entry.id === "default.triage-section.v1");
+
+    expect(nav).toBeDefined();
+    expect(triage).toBeDefined();
+    expect(codePoints(nav?.marker || "")).toEqual(["200e", "a0"]);
+    expect(codePoints(triage?.marker || "")).toEqual(["200c"]);
+    expect(triage?.placement).toBe("after-greeting-word");
+  });
+
+  it("keeps every dictionary marker approved and decodable", () => {
+    const approvedCodePoints = new Set(["200e", "a0", "200b", "200c", "200d", "2800"]);
+    const markedMessages = new Set<string>();
+
+    for (const entry of sourceCodedWhatsAppGreetings) {
+      expect(["prefix", "after-greeting-word"]).toContain(entry.placement);
+      for (const codePoint of codePoints(entry.marker)) {
+        expect(approvedCodePoints.has(codePoint)).toBe(true);
+      }
+
+      const marked = applySourceCodedWhatsAppMarker(entry);
+      expect(markedMessages.has(marked)).toBe(false);
+      markedMessages.add(marked);
+      expect(decodeSourceCodedWhatsAppMessage(marked)?.id).toBe(entry.id);
+    }
+  });
+
+  it("decodes prefix and after-greeting-word hidden markers", () => {
+    const prefix = buildWhatsAppMessage({ ctaLocation: "nav" });
+    const afterGreetingWord = buildWhatsAppMessage({ ctaLocation: "triage-section" });
+
+    expect(decodeSourceCodedWhatsAppMessage(prefix)?.id).toBe("default.nav.v1");
+    expect(decodeSourceCodedWhatsAppMessage(afterGreetingWord)?.id).toBe("default.triage-section.v1");
+  });
+
+  it("falls back from campaign attribution to the default touchpoint greeting", () => {
+    const exact = selectSourceCodedWhatsAppGreeting({
+      ctaLocation: "home-hero",
+      attribution: { utm_source: "google", utm_medium: "cpc", utm_campaign: "home" }
+    });
+    const fallback = selectSourceCodedWhatsAppGreeting({
+      ctaLocation: "home-hero",
+      attribution: { utm_source: "unknown", utm_campaign: "missing" }
+    });
+
+    expect(exact.id).toBe("google-cpc-home.home-hero.v1");
+    expect(fallback.id).toBe("default.home-hero.v1");
+  });
+
+  it("includes final composer fields without internal CTA or raw attribution text", () => {
     const url = buildWhatsAppUrl("5511999999999", {
       location: "São José dos Campos",
-      approximateAreaOrPerimeter: "12 ha",
-      objective: "regularizar matrícula",
-      deadline: "10 dias",
-      desiredDeliverable: "mapa e memorial",
-      selectedCluster: "Regularização Rural",
-      ctaLocation: "triage-card",
+      objective: "Regularização Rural",
+      ctaLocation: "final-cta",
       attribution: { utm_source: "google", gclid: "abc123" }
     });
-    const text = decodeURIComponent(url);
+    const text = textFromUrl(url);
 
+    expect(decodeSourceCodedWhatsAppMessage(text)?.id).toBe("default.final-cta.v1");
     expect(text).toContain("Localização: São José dos Campos.");
-    expect(text).toContain("Área/perímetro aproximado: 12 ha.");
-    expect(text).toContain("Objetivo: regularizar matrícula.");
-    expect(text).toContain("Prazo desejado: 10 dias.");
-    expect(text).toContain("Entrega desejada: mapa e memorial.");
-    expect(text).toContain("Cluster selecionado: Regularização Rural.");
-    expect(text).toContain("CTA: triage-card.");
-    expect(text).toContain("utm_source=google");
-    expect(text).toContain("gclid=abc123");
+    expect(text).toContain("Objetivo: Regularização Rural.");
+    expect(text).not.toContain("CTA:");
+    expect(text).not.toContain("Cluster selecionado");
+    expect(text).not.toContain("utm_source");
+    expect(text).not.toContain("gclid");
   });
 });


### PR DESCRIPTION
Why:
WhatsApp prefills were exposing internal CTA labels and raw attribution fields, and the default copy used orçamento language that does not match BLK's proposal-led commercial flow. The contact message should stay simple enough for leads to send unchanged while preserving campaign/source attribution for BLK.

What:
- Add an explicit source-coded WhatsApp greeting dictionary with hidden Unicode markers, marker placement, campaign/touchpoint selection, and decoding helpers.
- Keep WhatsApp visible text short and generic while preserving final composer location/objective fields when entered.
- Move attribution details out of WhatsApp text and into analytics payloads, preserving first-touch session attribution across later conflicting campaign params.
- Centralize client-side WhatsApp URL syncing through the shared helpers and expand unit/e2e coverage for marker and attribution behavior.

Validation:
- `node ./node_modules/vitest/vitest.mjs run tests/lib/whatsapp.test.ts tests/lib/attribution.test.ts` - 8 tests passed.
- `node ./node_modules/astro/astro.js build` - build succeeded, 9 pages built.
- `node ./node_modules/@playwright/test/cli.js test --config /tmp/homepage-pw-4322.config.mjs tests/e2e/conversion-flow.spec.ts tests/e2e/navigation-whatsapp.spec.ts tests/e2e/footer-social.spec.ts` - 10 tests passed.

Reviewer focus:
- Check the hidden marker dictionary in `src/lib/whatsapp.ts` for maintainability and future campaign expansion.
- Check that the client-side attribution merge and `whatsapp_click` payload preserve first-touch attribution while keeping WhatsApp text clean.
